### PR TITLE
Move PrintDefaults() to flag.Usage for '-h', '--help' option.

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 func _main() int {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "migemogrep v%s\n\nUsage: migemogrep [options] pattern [files...]\n", version)
+		flag.PrintDefaults()
 	}
 	var dictPath = flag.String("d", "", "Alternate location to dictionary")
 
@@ -34,7 +35,6 @@ func _main() int {
 
 	if flag.NArg() == 0 {
 		flag.Usage()
-		flag.PrintDefaults()
 		return 1
 	}
 


### PR DESCRIPTION
In original code, command line flag information is not displayed when `-h` or `--help`
flag is specified as below.

```
% migemogrep -h
migemogrep v0.1.0

Usage: migemogrep [options] pattern [files...
```

After applying this patch

```
% migemogrep -h
migemogrep v0.1.0

Usage: migemogrep [options] pattern [files...]
  -d="": Alternate location to dictionary
  -n=false: print line number with output lines
```
